### PR TITLE
Rename references to recap.

### DIFF
--- a/packages/ssx-sdk/src/extension.ts
+++ b/packages/ssx-sdk/src/extension.ts
@@ -4,13 +4,13 @@ import { SSXSession, SiweConfig } from './types';
 
 /** Interface for an extension to SSX. */
 export interface SSXExtension {
-    /** [capgrok] Capability namespace. */
+    /** [recap] Capability namespace. */
     namespace?: string,
-    /** [capgrok] Default delegated actions in capability namespace. */
+    /** [recap] Default delegated actions in capability namespace. */
     defaultActions?(): Promise<string[]>,
-    /** [capgrok] Delegated actions by target in capability namespace. */
+    /** [recap] Delegated actions by target in capability namespace. */
     targetedActions?(): Promise<{ [target: string]: string[] }>,
-    /** [capgrok] Extra metadata to help validate the capability. */
+    /** [recap] Extra metadata to help validate the capability. */
     extraFields?(): Promise<ExtraFields>,
     /** Hook to run after SSX has connected to the user's wallet.
      * This can return an object literal to override the session configuration before the user


### PR DESCRIPTION
CapGrok was renamed to ReCap. These are the only references to CapGrok in the codebase. There are also references in the generated documentation, but I assume those would get fixed automatically with this merged?