### PR TITLE
Update ssx-sdk requests to ssx-powered server 

### DIFF
--- a/packages/ssx-sdk/src/ssx.ts
+++ b/packages/ssx-sdk/src/ssx.ts
@@ -50,7 +50,7 @@ export class SSX {
   }
 
   /** Request the user to sign in, and start the session. */
-  async signIn() {
+  async signIn(): Promise<SSXSession> {
     try {
       this.connection = await this.init.connect();
     } catch (err) {
@@ -61,6 +61,7 @@ export class SSX {
 
     try {
       this.session = await this.connection.signIn();
+      return this.session;
     } catch (err) {
       // Request to /ssx-login went wrong
       console.error(err);
@@ -70,7 +71,7 @@ export class SSX {
 
   async signOut() {
     try {
-      await this.connection.signOut();
+      await this.connection.signOut(this.session);
       this.session = null;
       this.connection = null;
     } catch (err) {

--- a/packages/ssx-sdk/src/types.ts
+++ b/packages/ssx-sdk/src/types.ts
@@ -25,6 +25,7 @@ export enum StorageModule {
 /** Representation of an active SSXSession. */
 export type SSXSession = {
     address: string;
+    walletAddress: string;
     chainId: number;
     sessionKey: string;
     siwe: string;


### PR DESCRIPTION
This updates the getNonce, signIn and signOut parameters passed to the ssx-powered server. This is important to give more context and flexibility to the server when manipulating the session.

Please delete options that are not relevant:
- [x] New feature (non-breaking change which adds functionality)

How Has This Been Tested?
- [x] Unit tests
- [x] Integration Tests
- [x] E2E

System Configuration:
Node Version: 16.13.1
OS: ubuntu 20.04
Browser Version: Chrome 106.0.5249.119

Checklist:
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
