### PR TITLE
Update Generated Reference with SSX Serverless

### DIFF
--- a/scripts/build-docs.js
+++ b/scripts/build-docs.js
@@ -15,7 +15,7 @@ const getLines = (output, prefix = 'reference/ssx-sdk/', layer = 0) => {
 
 const generateReference = async () => {
   const output = {};
-  const dirs = [ './documentation/reference/ssx-sdk', './documentation/reference/ssx-server'];
+  const dirs = [ './documentation/reference/ssx-sdk', './documentation/reference/ssx-server', './documentation/reference/ssx-serverless'];
   const docFiles = [ ...(await Promise.all(dirs.map(async dir => await readdir(dir)))) ].reduce((p, c) => [...p, ...c], []);
   
   for (const docFile of docFiles) {
@@ -47,6 +47,8 @@ const generateReference = async () => {
         if (!output[nameParts[0]][nameParts[1]][nameParts[2]]) {
           output[nameParts[0]][nameParts[1]][nameParts[2]] = {};
         }
+      } else if (nameParts.length > 3){
+        console.log("Error: Not all documentation is being generated. Missing: ", nameParts.join('.'));
       }
     } catch (err) {
       console.error(`Could not process ${docFile}: ${err}`);
@@ -57,12 +59,13 @@ const generateReference = async () => {
     "## Reference",
     ...getLines({ 'ssx': output['ssx'] }),
     ...getLines({ 'ssx-server': output['ssx-server']}, 'reference/ssx-server/'),
+    ...getLines({ 'ssx-serverless': output['ssx-serverless']}, 'reference/ssx-serverless/'),
   ];
 
   let reference = lines.join('\n');
   reference = reference.replace('* [ssx]', '* [SSX API Reference]');
   reference = reference.replace('* [ssx-server]', '* [SSX Server API Reference]');
-
+  reference = reference.replace('* [ssx-serverless]', '* [SSX Serverless API Reference]');
   return reference;
 }
 
@@ -74,6 +77,7 @@ const generateSUMMARY = async () => {
   let reference = await generateReference();
   reference = reference.replace(/^\* \[ssx\]/, '* [SSX API Reference]');
   reference = reference.replace(/^\* \[ssx-server\]/, '* [SSX Server API Reference]');
+  reference = reference.replace(/^\* \[ssx-serverless\]/, '* [SSX Serverless API Reference]');
   await writeFile('./documentation/SUMMARY.md', previous.concat(reference));
 }
 


### PR DESCRIPTION
# Description
Files not included in the generated reference are unable to be linked on Gitbook. This PR makes sure files generated from ssx-serverless are included in the generated reference and are linkable.

# Type
- [x] New feature (non-breaking change which adds functionality)

# Diligence Checklist
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
