### PR TITLE
Adds check to prevent signature when API is enabled but no nonce is returned

### DIFF
--- a/.changeset/happy-suits-kick.md
+++ b/.changeset/happy-suits-kick.md
@@ -1,0 +1,5 @@
+---
+"@spruceid/ssx": minor
+---
+
+Throws an error in case an API is configured but no nonce is returned from it.

--- a/packages/ssx-sdk/src/core.ts
+++ b/packages/ssx-sdk/src/core.ts
@@ -193,8 +193,11 @@ export class SSXConnected {
       nonce: generateNonce(),
     };
 
-    const serverNonce = await this.ssxServerNonce(defaults);
-    if (serverNonce) defaults.nonce = serverNonce;
+    defaults.nonce = await this.ssxServerNonce(defaults);
+
+    if(this.api && !defaults.nonce) {
+      throw new Error('Unable to retrieve nonce from server.');
+    }
 
     const siweConfig = merge(defaults, this.config.siweConfig);
 

--- a/packages/ssx-sdk/src/core.ts
+++ b/packages/ssx-sdk/src/core.ts
@@ -139,6 +139,9 @@ export class SSXConnected {
     try {
       if (this.api) {
         const { data: nonce } = await this.api.get('/ssx-nonce', { params });
+        if (!nonce) {
+          throw new Error('Unable to retrieve nonce from server.');
+        }
         return nonce;
       }
     } catch (error) {
@@ -193,11 +196,8 @@ export class SSXConnected {
       nonce: generateNonce(),
     };
 
-    defaults.nonce = await this.ssxServerNonce(defaults);
-
-    if(this.api && !defaults.nonce) {
-      throw new Error('Unable to retrieve nonce from server.');
-    }
+    const serverNonce = await this.ssxServerNonce(defaults);
+    if (serverNonce) defaults.nonce = serverNonce;
 
     const siweConfig = merge(defaults, this.config.siweConfig);
 


### PR DESCRIPTION
If server is enabled but the call to `/ssx-nonce` the signature process would still occur even though it will result in a fail because of nonce mismatch. This throws an error in case this scenario happens.

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
