### PR TITLE
Change configs to publish relevant packages with Changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "fixed": [],
   "linked": [],
-  "access": "restricted",
+  "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": []

--- a/examples/ssx-test-express-api/package.json
+++ b/examples/ssx-test-express-api/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "main": "dist/index.js",
+  "private": true,
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",

--- a/examples/ssx-test-http-api/package.json
+++ b/examples/ssx-test-http-api/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "main": "dist/index.js",
+  "private": true,
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",


### PR DESCRIPTION
# Description

Updated changesets config, so that publishing packages no longer generates a warning. Also updated all example `package.json`s to be private, so that they are not attempted to published

# Type
- [x] Chore
