### PR TITLE
Fix: Suppress SSX-Middleware Exceptions

### DIFF
--- a/.changeset/orange-rice-accept.md
+++ b/.changeset/orange-rice-accept.md
@@ -2,4 +2,4 @@
 '@spruceid/ssx-server': patch
 ---
 
-Enabled `suppressExceptions` to provent verification errors from cause middleware crashes
+Improved promise resolution to the verification of the Siwe Message, preventing potential exceptions coming from the middleware.

--- a/.changeset/orange-rice-accept.md
+++ b/.changeset/orange-rice-accept.md
@@ -1,0 +1,5 @@
+---
+'@spruceid/ssx-server': patch
+---
+
+Enabled `suppressExceptions` to provent verification errors from cause middleware crashes

--- a/packages/ssx-server/src/middlewares/express/middleware.ts
+++ b/packages/ssx-server/src/middlewares/express/middleware.ts
@@ -88,12 +88,13 @@ export const ssxMiddleware = (ssx: SSXServer) => {
 
     if (req.session?.siwe) {
       const { signature, siwe, daoLogin, nonce } = req.session;
-      const { success: verified, data } = await new SiweMessage(siwe).verify(
-        { signature, nonce },
-        {
-          verificationFallback: daoLogin ? SiweGnosisVerify : null,
-          provider: ssx.provider,
-        },
+      const { success: verified, data } = await new SiweMessage(siwe)
+        .verify(
+          { signature, nonce },
+          {
+            verificationFallback: daoLogin ? SiweGnosisVerify : null,
+            provider: ssx.provider,
+          },
         )
         .then((data) => ({ success: true, data }))
         .catch((error) => ({ success: false, error, data: null }));

--- a/packages/ssx-server/src/middlewares/express/middleware.ts
+++ b/packages/ssx-server/src/middlewares/express/middleware.ts
@@ -88,16 +88,14 @@ export const ssxMiddleware = (ssx: SSXServer) => {
 
     if (req.session?.siwe) {
       const { signature, siwe, daoLogin, nonce } = req.session;
-      let siweMessageVerify;
-      try {
-        siweMessageVerify = await new SiweMessage(siwe).verify(
-          { signature, nonce },
-          {
-            verificationFallback: daoLogin ? SiweGnosisVerify : null,
-            provider: ssx.provider,
-          },
-        );
-      } catch (error) {}
+      const siweMessageVerify = await new SiweMessage(siwe).verify(
+        { signature, nonce },
+        {
+          verificationFallback: daoLogin ? SiweGnosisVerify : null,
+          suppressExceptions: true,
+          provider: ssx.provider,
+        },
+      );
       const { success: verified, data } = siweMessageVerify;
       if (verified) {
         req.ssx = {

--- a/packages/ssx-server/src/middlewares/express/middleware.ts
+++ b/packages/ssx-server/src/middlewares/express/middleware.ts
@@ -88,15 +88,15 @@ export const ssxMiddleware = (ssx: SSXServer) => {
 
     if (req.session?.siwe) {
       const { signature, siwe, daoLogin, nonce } = req.session;
-      const siweMessageVerify = await new SiweMessage(siwe).verify(
+      const { success: verified, data } = await new SiweMessage(siwe).verify(
         { signature, nonce },
         {
           verificationFallback: daoLogin ? SiweGnosisVerify : null,
-          suppressExceptions: true,
           provider: ssx.provider,
         },
-      );
-      const { success: verified, data } = siweMessageVerify;
+        )
+        .then((data) => ({ success: true, data }))
+        .catch((error) => ({ success: false, error, data: null }));
       if (verified) {
         req.ssx = {
           ...req.ssx,


### PR DESCRIPTION
# Description

This PR passes a flag to `siwe` in `ssx-middleware` to prevent exceptions from causing the middleware to crash. [More context](https://github.com/spruceid/siwe/blob/main/packages/siwe/lib/types.ts#L30) on `suppressExceptions`

# Type

- [x] Bug fix (non-breaking change which fixes an issue)

# Diligence Checklist
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
