### PR TITLE
SSX v1.1.1

### DIFF
--- a/.changeset/bright-clocks-design.md
+++ b/.changeset/bright-clocks-design.md
@@ -1,6 +1,0 @@
----
-'@spruceid/ssx-core': patch
-'@spruceid/ssx-server': patch
----
-
-Updated `SSXServerRoutes` type to `SSXServerRouteNames` to reflect usage in ssx-server

--- a/.changeset/shaggy-camels-sit.md
+++ b/.changeset/shaggy-camels-sit.md
@@ -1,6 +1,0 @@
----
-'@spruceid/ssx-core': patch
-'@spruceid/ssx': patch
----
-
-Update the `SSXServerRoutes` type to accept a route configuration compatible with [Axios Request Config](SSXServerRoutes) to allow for more complex server configurations.

--- a/packages/ssx-core/CHANGELOG.md
+++ b/packages/ssx-core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @spruceid/ssx-core
 
+## 1.0.1
+
+### Patch Changes
+
+- b25cbde: Updated `SSXServerRoutes` type to `SSXServerRouteNames` to reflect usage in ssx-server
+- b25cbde: Update the `SSXServerRoutes` type to accept a route configuration compatible with [Axios Request Config](SSXServerRoutes) to allow for more complex server configurations.
+
 ## 1.0.0
 
 Initial Release

--- a/packages/ssx-core/package.json
+++ b/packages/ssx-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spruceid/ssx-core",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "SSX core library",
   "author": "Spruce Systems Inc.",
   "license": "Apache-2.0 OR MIT",

--- a/packages/ssx-gnosis-extension/CHANGELOG.md
+++ b/packages/ssx-gnosis-extension/CHANGELOG.md
@@ -1,10 +1,19 @@
 # @spruceid/ssx-gnosis-extension
 
+## 1.1.1
+
+### Patch Changes
+
+- Updated dependencies [b25cbde]
+- Updated dependencies [b25cbde]
+  - @spruceid/ssx-core@1.0.1
+
 ## 1.1.0
 
 ### Minor Changes
 
 - c989838: Refactor code to avoid duplication and improve performance.
+
   - Adds `@spruceid/ssx-core` as a dependency;
   - Adds types from `ssx-core` to all SSX related variables;
   - Optimizes `try/catch` blocks.

--- a/packages/ssx-gnosis-extension/CHANGELOG.md
+++ b/packages/ssx-gnosis-extension/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Patch Changes
 
 - Updated dependencies [b25cbde]
-- Updated dependencies [b25cbde]
   - @spruceid/ssx-core@1.0.1
 
 ## 1.1.0

--- a/packages/ssx-react/CHANGELOG.md
+++ b/packages/ssx-react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @spruceid/ssx-react
 
+## 1.1.1
+
+### Patch Changes
+
+- Updated dependencies [b25cbde]
+  - @spruceid/ssx@1.1.1
+
 ## 1.1.0
 
 ### Minor Changes
@@ -9,6 +16,7 @@
 ### Patch Changes
 
 - c989838: Refactor code to avoid duplication and improve performance.
+
   - Updates `ssxConfig?: SSXConfig;` on `SSXProviderProps` to `ssxConfig?: SSXClientConfig;` (non breaking change).
 
 - Updated dependencies [c989838]

--- a/packages/ssx-sdk/CHANGELOG.md
+++ b/packages/ssx-sdk/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @spruceid/ssx
 
+## 1.1.1
+
+### Patch Changes
+
+- b25cbde: Update the `SSXServerRoutes` type to accept a route configuration compatible with [Axios Request Config](SSXServerRoutes) to allow for more complex server configurations.
+- Updated dependencies [b25cbde]
+- Updated dependencies [b25cbde]
+  - @spruceid/ssx-core@1.0.1
+  - @spruceid/ssx-gnosis-extension@1.1.1
+
 ## 1.1.0
 
 ### Minor Changes

--- a/packages/ssx-sdk/CHANGELOG.md
+++ b/packages/ssx-sdk/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 - b25cbde: Update the `SSXServerRoutes` type to accept a route configuration compatible with [Axios Request Config](SSXServerRoutes) to allow for more complex server configurations.
 - Updated dependencies [b25cbde]
-- Updated dependencies [b25cbde]
   - @spruceid/ssx-core@1.0.1
   - @spruceid/ssx-gnosis-extension@1.1.1
 

--- a/packages/ssx-sdk/package.json
+++ b/packages/ssx-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spruceid/ssx",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "An identity solution that enables SSI to JS/TS dApps.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -27,8 +27,8 @@
   "dependencies": {
     "@metamask/detect-provider": "^1.2.0",
     "siwe": "^2.1.2",
-    "@spruceid/ssx-core": "1.0.0",
-    "@spruceid/ssx-gnosis-extension": "1.1.0",
+    "@spruceid/ssx-core": "1.0.1",
+    "@spruceid/ssx-gnosis-extension": "1.1.1",
     "@spruceid/ssx-sdk-wasm": "0.1.2",
     "@types/lodash.merge": "^4.6.7",
     "assert": "^2.0.0",

--- a/packages/ssx-server/CHANGELOG.md
+++ b/packages/ssx-server/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @spruceid/ssx-server
 
+## 1.1.1
+
+### Patch Changes
+
+- b25cbde: Updated `SSXServerRoutes` type to `SSXServerRouteNames` to reflect usage in ssx-server
+- Updated dependencies [b25cbde]
+- Updated dependencies [b25cbde]
+  - @spruceid/ssx-core@1.0.1
+
 ## 1.1.0
 
 ### Minor Changes
@@ -28,6 +37,7 @@
 ### Patch Changes
 
 - c989838: Refactor code to avoid duplication and improve performance.
+
   - Adds `@spruceid/ssx-core` as a dependency;
   - Removes all types and interfaces declarations. They were moved to `ssx-core`;
   - Exports `SSXConfig` (deprecated) and `SSXServerConfig`;

--- a/packages/ssx-server/CHANGELOG.md
+++ b/packages/ssx-server/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 - b25cbde: Updated `SSXServerRoutes` type to `SSXServerRouteNames` to reflect usage in ssx-server
 - Updated dependencies [b25cbde]
-- Updated dependencies [b25cbde]
   - @spruceid/ssx-core@1.0.1
 
 ## 1.1.0

--- a/packages/ssx-server/package.json
+++ b/packages/ssx-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spruceid/ssx-server",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "Spruce Systems, Inc.",
@@ -23,8 +23,8 @@
     "ssx-server": "bin/ssx-server.js"
   },
   "dependencies": {
-    "@spruceid/ssx-core": "1.0.0",
-    "@spruceid/ssx-gnosis-extension": "1.1.0",
+    "@spruceid/ssx-core": "1.0.1",
+    "@spruceid/ssx-gnosis-extension": "1.1.1",
     "axios": "^0.27.2",
     "body-parser": "^1.20.0",
     "cookie-parser": "^1.4.6",

--- a/packages/ssx-serverless/CHANGELOG.md
+++ b/packages/ssx-serverless/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Patch Changes
 
 - Updated dependencies [b25cbde]
-- Updated dependencies [b25cbde]
   - @spruceid/ssx-core@1.0.1
   - @spruceid/ssx-gnosis-extension@1.1.1
 

--- a/packages/ssx-serverless/CHANGELOG.md
+++ b/packages/ssx-serverless/CHANGELOG.md
@@ -1,10 +1,20 @@
 # @spruceid/ssx-serverless
 
+## 1.1.1
+
+### Patch Changes
+
+- Updated dependencies [b25cbde]
+- Updated dependencies [b25cbde]
+  - @spruceid/ssx-core@1.0.1
+  - @spruceid/ssx-gnosis-extension@1.1.1
+
 ## 1.1.0
 
 ### Minor Changes
 
 - c989838: Refactor code to avoid duplication and improve performance.
+
   - Adds `@spruceid/ssx-core` as a dependency;
   - Removes some types and interfaces declarations. They were moved to `ssx-core`;
   - Removes all utils functions. They were moved to `ssx-core`;


### PR DESCRIPTION
# Description

This PR bumps the patch versions of the libraries in the SSX Monorepo to v1.1.1. It has imporovements to `ssx-core`, `ssx-server` and `ssx-sdk`


# Type
- [x] Release

