### PR TITLE
Update resolve Lens test

### DIFF
--- a/packages/ssx-core/tests/utils.test.ts
+++ b/packages/ssx-core/tests/utils.test.ts
@@ -210,7 +210,7 @@ test('Should resolve Lens profile on Mumbai Testnet successfully', async () => {
     expect.objectContaining({
       pageInfo: {
         prev: '{"offset":0}',
-        next: '{"offset":0}',
+        next: null,
         totalCount: 0,
       }
     })


### PR DESCRIPTION
# Description

This PR updates the test "Should resolve Lens profiles on Mumbai Testnet successfully" on ssx-core. 

Lens API response changed when there are no profiles to return. Before, it returned an object in the format:
```js
{
    items: [],
    pageInfo: {
        prev: '{"offset":0}',
        next:  '{"offset":0}',
        totalCount: 0,
      }
}
```
And now it returns:
```js
{
    items: [],
    pageInfo: {
        prev: '{"offset":0}',
        next: null,
        totalCount: 0,
      }
}
```
# Type

- [x] Test update

# Diligence Checklist

- [x] I have included/update tests