### PR TITLE
Make gulp example private

### DIFF
--- a/examples/ssx-test-gulp-dapp/package.json
+++ b/examples/ssx-test-gulp-dapp/package.json
@@ -2,6 +2,7 @@
   "name": "ssx-test-gulp-dapp",
   "version": "1.0.0",
   "main": "index.js",
+  "private": true,
   "repository": {
     "url": "ssh://git@github.com:spruceid/ssx.git"
   },


### PR DESCRIPTION
# Description

Set this flag to be private to prevent it from being published with `changeset publish` command.

# Type

- [x] Bug fix (non-breaking change which fixes an issue)