### PR TITLE
Expose Connect and Extend

### DIFF
--- a/.changeset/shaggy-spoons-try.md
+++ b/.changeset/shaggy-spoons-try.md
@@ -2,4 +2,4 @@
 '@spruceid/ssx': patch
 ---
 
-Separated adn exposed the connect function to connect the SSX instance to the ethereum provider. Also exposed the extension interface to allow for extensions to SSX
+Separated and exposed the connect function to connect the SSX instance to the ethereum provider. Also exposed the extension interface to allow for extensions to SSX

--- a/.changeset/shaggy-spoons-try.md
+++ b/.changeset/shaggy-spoons-try.md
@@ -1,0 +1,5 @@
+---
+'@spruceid/ssx': patch
+---
+
+Separated adn exposed the connect function to connect the SSX instance to the ethereum provider. Also exposed the extension interface to allow for extensions to SSX

--- a/packages/ssx-sdk/src/ssx.ts
+++ b/packages/ssx-sdk/src/ssx.ts
@@ -12,7 +12,8 @@ import {
   SSXClientConfig,
   SSXClientSession,
 } from '@spruceid/ssx-core/client';
-
+import type { ethers } from 'ethers';
+import { SSXExtension } from '../../ssx-core/dist/client/types';
 declare global {
   interface Window {
     ethereum?: any;
@@ -34,6 +35,9 @@ const SSX_DEFAULT_CONFIG: SSXClientConfig = {
 export class SSX {
   /** SSXClientSession builder. */
   private init: SSXInit;
+
+  /** The Ethereum provider */
+  public provider: ethers.providers.Web3Provider;
 
   /** The session representation (once signed in). */
   public session?: SSXClientSession;
@@ -57,17 +61,36 @@ export class SSX {
   }
 
   /**
-   * Request the user to sign in, and start the session.
-   * @returns Object containing information about the session
+   * Extends SSX with a functions that are called after connecting and signing in.
    */
-  public async signIn(): Promise<SSXClientSession> {
+  public extend(extension: SSXExtension): void {
+    this.init.extend(extension);
+  }
+
+  /**
+   * Connects the SSX instance to the Ethereum provider.
+   */
+  public async connect(): Promise<void> {
+    if (this.connection) {
+      return;
+    }
     try {
       this.connection = await this.init.connect();
+      this.provider = this.connection.provider;
     } catch (err) {
+      // ERROR:
       // Something went wrong when connecting or creating Session (wasm)
       console.error(err);
       throw err;
     }
+  }
+
+  /**
+   * Request the user to sign in, and start the session.
+   * @returns Object containing information about the session
+   */
+  public async signIn(): Promise<SSXClientSession> {
+    await this.connect();
 
     try {
       this.session = await this.connection.signIn();

--- a/packages/ssx-sdk/src/ssx.ts
+++ b/packages/ssx-sdk/src/ssx.ts
@@ -11,9 +11,9 @@ import {
 import {
   SSXClientConfig,
   SSXClientSession,
+  SSXExtension,
 } from '@spruceid/ssx-core/client';
 import type { ethers } from 'ethers';
-import { SSXExtension } from '../../ssx-core/dist/client/types';
 declare global {
   interface Window {
     ethereum?: any;

--- a/packages/ssx-sdk/src/ssx.ts
+++ b/packages/ssx-sdk/src/ssx.ts
@@ -78,7 +78,6 @@ export class SSX {
       this.connection = await this.init.connect();
       this.provider = this.connection.provider;
     } catch (err) {
-      // ERROR:
       // Something went wrong when connecting or creating Session (wasm)
       console.error(err);
       throw err;

--- a/packages/ssx-sdk/tests/ssx.test.ts
+++ b/packages/ssx-sdk/tests/ssx.test.ts
@@ -2,7 +2,7 @@ const { ethers } = require('ethers');
 const { generateTestingUtils } = require('eth-testing');
 const { TextEncoder: TE, TextDecoder: TD } = require('util');
 
-jest.mock('axios')
+jest.mock('axios');
 
 global.TextEncoder = TE;
 global.TextDecoder = TD;
@@ -18,7 +18,9 @@ test('Instantiate SSX with window.ethereum', () => {
 test('Instantiate SSX with providers.web3.driver and successfully sign in and sign out', async () => {
   const testingUtils = generateTestingUtils({ providerType: 'MetaMask' });
   testingUtils.mockChainId('0x5');
-  testingUtils.mockConnectedWallet(['0x96F7fB7ed32640d9D3a982f67CD6c09fc53EBEF1']);
+  testingUtils.mockConnectedWallet([
+    '0x96F7fB7ed32640d9D3a982f67CD6c09fc53EBEF1',
+  ]);
   const config = {
     providers: {
       web3: {
@@ -34,14 +36,16 @@ test('Instantiate SSX with providers.web3.driver and successfully sign in and si
 test('Instantiate SSX with providers.web3.driver and daoLogin', async () => {
   const testingUtils = generateTestingUtils({ providerType: 'MetaMask' });
   testingUtils.mockChainId('0x1');
-  testingUtils.mockConnectedWallet(['0x456c1182DecC365DCFb5F981dCaef671C539AD44']);
+  testingUtils.mockConnectedWallet([
+    '0x456c1182DecC365DCFb5F981dCaef671C539AD44',
+  ]);
   const abi = [
     'event SetDelegate(address indexed delegator, bytes32 indexed id, address indexed delegate)',
     'event ClearDelegate(address indexed delegator, bytes32 indexed id, address indexed delegate)',
   ] as const;
   const contractTestingUtils = testingUtils.generateContractUtils(abi);
-  contractTestingUtils.mockGetLogs("SetDelegate", []);
-  contractTestingUtils.mockGetLogs("ClearDelegate", []);
+  contractTestingUtils.mockGetLogs('SetDelegate', []);
+  contractTestingUtils.mockGetLogs('ClearDelegate', []);
   const config = {
     providers: {
       web3: {
@@ -57,7 +61,9 @@ test('Instantiate SSX with providers.web3.driver and daoLogin', async () => {
 test('Instantiate SSX with providers.web3.driver and server and successfully sign in and sign out', async () => {
   const testingUtils = generateTestingUtils({ providerType: 'MetaMask' });
   testingUtils.mockChainId('0x5');
-  testingUtils.mockConnectedWallet(['0x96F7fB7ed32640d9D3a982f67CD6c09fc53EBEF1']);
+  testingUtils.mockConnectedWallet([
+    '0x96F7fB7ed32640d9D3a982f67CD6c09fc53EBEF1',
+  ]);
   const config = {
     providers: {
       web3: {
@@ -65,24 +71,22 @@ test('Instantiate SSX with providers.web3.driver and server and successfully sig
       },
       server: {
         host: 'http://localhost:3001',
-      }
+      },
     },
   };
   const ssx = new SSX(config);
 
-  const mockAxios = jest.requireMock("axios");
-  mockAxios.default.create = jest
-    .fn()
-    .mockImplementation(() => ({
-      request: async (props: { url: string }) => {
-        switch (props.url) {
-          case '/ssx-nonce':
-            return { data: 'ZH54GNgkQWB887iJU' };
-          default:
-            return { data: {} };
-        }
+  const mockAxios = jest.requireMock('axios');
+  mockAxios.default.create = jest.fn().mockImplementation(() => ({
+    request: async (props: { url: string }) => {
+      switch (props.url) {
+        case '/ssx-nonce':
+          return { data: 'ZH54GNgkQWB887iJU' };
+        default:
+          return { data: {} };
       }
-    }));
+    },
+  }));
 
   await expect(ssx.signIn()).resolves.not.toThrowError();
   await expect(ssx.signOut()).resolves.not.toThrowError();
@@ -146,6 +150,26 @@ test('Should accept axios request config options successfully', async () => {
       },
     });
   }).not.toThrowError();
+});
+
+test('Should accept extensions successfully', async () => {
+  // import { GnosisDelegation } from '@spruceid/ssx-gnosis-extension';
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { GnosisDelegation } = require('@spruceid/ssx-gnosis-extension');
+  const testingUtils = generateTestingUtils({ providerType: 'MetaMask' });
+  const ssxConfig = {
+    providers: {
+      web3: {
+        driver: new ethers.providers.Web3Provider(testingUtils.getProvider()),
+      },
+    },
+  };
+  const ssx = new SSX(ssxConfig);
+  const gnosis = new GnosisDelegation();
+  ssx.extend(gnosis);
+
+  await expect(ssx.signIn()).resolves.not.toThrowError();
+
 });
 
 // test('Connect to wallet', async () => {

--- a/packages/ssx-sdk/tests/ssx.test.ts
+++ b/packages/ssx-sdk/tests/ssx.test.ts
@@ -153,7 +153,9 @@ test('Should accept axios request config options successfully', async () => {
 });
 
 test('Should accept extensions successfully', async () => {
-  const GnosisDelegation = (await import('@spruceid/ssx-gnosis-extension')).GnosisDelegation;
+  jest.setTimeout(30000);
+  const GnosisDelegation = (await import('@spruceid/ssx-gnosis-extension'))
+    .GnosisDelegation;
   const testingUtils = generateTestingUtils({ providerType: 'MetaMask' });
   testingUtils.mockChainId('0x1');
   testingUtils.mockConnectedWallet([

--- a/packages/ssx-sdk/tests/ssx.test.ts
+++ b/packages/ssx-sdk/tests/ssx.test.ts
@@ -153,10 +153,19 @@ test('Should accept axios request config options successfully', async () => {
 });
 
 test('Should accept extensions successfully', async () => {
-  // import { GnosisDelegation } from '@spruceid/ssx-gnosis-extension';
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const { GnosisDelegation } = require('@spruceid/ssx-gnosis-extension');
+  const GnosisDelegation = (await import('@spruceid/ssx-gnosis-extension')).GnosisDelegation;
   const testingUtils = generateTestingUtils({ providerType: 'MetaMask' });
+  testingUtils.mockChainId('0x1');
+  testingUtils.mockConnectedWallet([
+    '0x456c1182DecC365DCFb5F981dCaef671C539AD44',
+  ]);
+  const abi = [
+    'event SetDelegate(address indexed delegator, bytes32 indexed id, address indexed delegate)',
+    'event ClearDelegate(address indexed delegator, bytes32 indexed id, address indexed delegate)',
+  ] as const;
+  const contractTestingUtils = testingUtils.generateContractUtils(abi);
+  contractTestingUtils.mockGetLogs('SetDelegate', []);
+  contractTestingUtils.mockGetLogs('ClearDelegate', []);
   const ssxConfig = {
     providers: {
       web3: {
@@ -169,31 +178,4 @@ test('Should accept extensions successfully', async () => {
   ssx.extend(gnosis);
 
   await expect(ssx.signIn()).resolves.not.toThrowError();
-
 });
-
-// test('Connect to wallet', async () => {
-//   // TODO: expose wallet connection interface
-// });
-
-// test('Sign-in with Ethereum', () => {
-//   // TODO: sign request with mock provider
-//   expect(async () => {
-//     const config = {
-//       providers: {
-//         web3: {
-//           driver: provider,
-//         },
-//       },
-//     };
-//     const ssx = new SSX(config);
-//     await ssx.signIn();
-//   }).not.toThrowError();
-// });
-
-// test('Throw Error if Ethereum Wallet isn\'t found', () => {
-//   // TODO: Throw error if no wallet is found
-//   // global.window.ethereum = undefined;
-//   // const ssx = ;
-//   // expect(() => { const ssx = new SSX(); ssx.signIn(); }).toThrowError('An ethereum wallet extension is not installed.');
-// });


### PR DESCRIPTION
# Description

This PR exposes the `connect` and `extend` functionality on SSX. This allows someone to connect the SSX instance to the Ethereum provider without logging in. It also exposes the extend functionality to add extensions to SSX outside of the constructor.

These changes will also help with implementing features in `ssx-credential-issuer`

# Type

- [x] New feature (non-breaking change which adds functionality)

# Diligence Checklist

- [x] This change requires a documentation update
- [x] I have included unit tests
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
