### PR TITLE
SSX React Release v1.2.4

### DIFF
--- a/packages/ssx-react/CHANGELOG.md
+++ b/packages/ssx-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @spruceid/ssx-react
 
+## 1.2.4
+
+### Patch Changes
+
+- This updates the ssx-react package in order to improve compatibility between all wagmi/rainbow-kit versions.
+
 ## 1.2.3
 
 ### Patch Changes

--- a/packages/ssx-react/package.json
+++ b/packages/ssx-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spruceid/ssx-react",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "SSX React Hooks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
# Description

This PR has the version bump for `ssx-react` v1.2.4

# Type

- [x] Release