### PR TITLE
Updates gnosis modal to completely load contents before showing to av…

### DIFF
--- a/packages/ssx-gnosis-extension/src/modal.ts
+++ b/packages/ssx-gnosis-extension/src/modal.ts
@@ -320,7 +320,6 @@ export class GnosisDelegation implements SSXExtension {
     modalCounter.textContent = '';
     modalCounter.insertAdjacentHTML('beforeend', '&nbsp;');
     continueBtn.classList.add('disabled');
-    modal.classList.add('visible');
     const modalBodyContent = document.createElement('div');
     await this.getOptions()
       .then(async options => {
@@ -350,6 +349,8 @@ export class GnosisDelegation implements SSXExtension {
             modalBody.replaceChildren(modalBodyContent);
             modalCounter.textContent = `${options.length} result${options.length > 1 ? 's' : ''
               }`;
+
+            modal.classList.add('visible');
           })
           .catch(e => {
             console.error(e);
@@ -367,10 +368,16 @@ export class GnosisDelegation implements SSXExtension {
             modalBody.replaceChildren(modalBodyContent);
             modalCounter.textContent = `${options.length} result${options.length > 1 ? 's' : ''
               }`;
+            if (!modal.classList.contains('visible')) {
+              modal.classList.add('visible');
+            }
           });
       })
       .catch(e => {
         console.error(e);
+        if (!modal.classList.contains('visible')) {
+          modal.classList.add('visible');
+        }
         modalBody.replaceChildren(getErrorModal());
       });
   };


### PR DESCRIPTION
…oid a flash in the UI

# Description

This PR changes how the gnosis modal loads, moving it's shift into visibility to after the asynchronous code and delegation loading. This should avoid a grey flash in the UI reported in issue #90. I have NOT been able to replicate this locally, so my changes are just a best guess. More testing from other users would be appreciated.

# Type

- [X] Bug fix (non-breaking change which fixes an issue)

# Diligence Checklist

(Please delete options that are not relevant)

- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
