### PR TITLE
Updates gnosis modal to completely load contents before showing to av…

### DIFF
--- a/.changeset/small-ravens-melt.md
+++ b/.changeset/small-ravens-melt.md
@@ -1,0 +1,5 @@
+---
+'@spruceid/ssx-gnosis-extension': patch
+---
+
+Updates the modal code to prevent it showing before it finishes loading. This change should prevent a flash in the modal

--- a/packages/ssx-gnosis-extension/src/modal.ts
+++ b/packages/ssx-gnosis-extension/src/modal.ts
@@ -320,7 +320,6 @@ export class GnosisDelegation implements SSXExtension {
     modalCounter.textContent = '';
     modalCounter.insertAdjacentHTML('beforeend', '&nbsp;');
     continueBtn.classList.add('disabled');
-    modal.classList.add('visible');
     const modalBodyContent = document.createElement('div');
     await this.getOptions()
       .then(async options => {
@@ -350,9 +349,11 @@ export class GnosisDelegation implements SSXExtension {
             modalBody.replaceChildren(modalBodyContent);
             modalCounter.textContent = `${options.length} result${options.length > 1 ? 's' : ''
               }`;
+            modal.classList.add('visible');
           })
           .catch(e => {
             console.error(e);
+
             [this.selectedOption, ...options].forEach(option => {
               const newOption = document.createElement('div');
               newOption.setAttribute(
@@ -367,11 +368,17 @@ export class GnosisDelegation implements SSXExtension {
             modalBody.replaceChildren(modalBodyContent);
             modalCounter.textContent = `${options.length} result${options.length > 1 ? 's' : ''
               }`;
+            if (!modal.classList.contains('visible')) {
+              modal.classList.add('visible');
+            }
           });
       })
       .catch(e => {
         console.error(e);
         modalBody.replaceChildren(getErrorModal());
+        if (!modal.classList.contains('visible')) {
+          modal.classList.add('visible');
+        }
       });
   };
 


### PR DESCRIPTION
…oid a flash in the UI

# Description

Updates where the modal is shown to avoid issues with it flashing grey in the UI. Tested locally using `ssx-test-dapp`, additional testing would be appreciated, because I wasn't able to reproduce on my own.

# Type

- [X] Bug fix (non-breaking change which fixes an issue)

# Diligence Checklist

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
