### PR TITLE
Adds SSX_SIGNING_KEY on SSX test:e2e script

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "start:test-api": "yarn express-api start",
     "prepare-release": "changeset version",
     "publish-packages": "yarn reset && yarn install && yarn build && changeset publish",
-    "test:e2e": "start-test 'yarn start:test-dapp' 3000 'yarn start:test-api' 3001 'SECRET_WORDS=\"test test test test test test test test test test test junk\" synpress run'"
+    "test:e2e": "start-test 'yarn start:test-dapp' 3000 'SSX_SIGNING_KEY=test_key yarn start:test-api' 3001 'SECRET_WORDS=\"test test test test test test test test test test test junk\" synpress run'"
   },
   "devDependencies": {
     "@changesets/cli": "^2.25.0",


### PR DESCRIPTION
# Description

This adds the SSX_SIGNING_KEY env variable when running the test:e2e scripts. This is required to run E2E tests in a freshly cloned repo.

# Type

- [x] Update script.
