### PR TITLE
Fix SSX freezing when rejecting on multisig modal

### DIFF
--- a/.changeset/gentle-hairs-rule.md
+++ b/.changeset/gentle-hairs-rule.md
@@ -1,0 +1,5 @@
+---
+'@spruceid/ssx-gnosis-extension': patch
+---
+
+This fixes the SSX instance freezing if multisig modal is closed during the sign-in process.

--- a/packages/ssx-gnosis-extension/src/modal.ts
+++ b/packages/ssx-gnosis-extension/src/modal.ts
@@ -16,6 +16,8 @@ let delegators: Array<string> = [];
 
 /** Gnosis Modal Interface */
 interface IGnosisModal {
+  /** Method to abort operation handling an error and close the modal. */
+  abortOperation: (message: string) => void;
   /** Method to close the modal. */
   closeModal: () => void;
   /** Method to open modal. */
@@ -147,7 +149,7 @@ const getBaseModal = (): Element => {
   // Backdrop
   const backdrop = document.createElement('span');
   backdrop.classList.add('ssx-gnosis-modal--backdrop');
-  backdrop.onclick = window.gnosisModal.closeModal;
+  backdrop.onclick = () => window.gnosisModal.abortOperation('Operation aborted by the user.');
   container.appendChild(backdrop);
 
   // Brand
@@ -201,7 +203,7 @@ const getBaseModal = (): Element => {
   brand.appendChild(divSafe);
   // Close button
   const closeBtn = document.createElement('button');
-  closeBtn.onclick = window.gnosisModal.closeModal;
+  closeBtn.onclick = () => window.gnosisModal.abortOperation('Operation aborted by the user.');
   const svgClose = document.createElementNS(
     'http://www.w3.org/2000/svg',
     'svg'
@@ -242,7 +244,7 @@ const getBaseModal = (): Element => {
   // Close button
   const footerCloseBtn = document.createElement('button');
   footerCloseBtn.classList.add('ssx-gnosis-modal--btn', 'secondary');
-  footerCloseBtn.onclick = window.gnosisModal.closeModal;
+  footerCloseBtn.onclick = () => window.gnosisModal.abortOperation('Operation aborted by the user.');
   footerCloseBtn.appendChild(document.createTextNode('Cancel'));
   // Continue button
   const continueBtn = document.createElement('button');
@@ -296,6 +298,7 @@ export class GnosisDelegation implements SSXExtension {
     this._connectedAddress = await ssx.provider.getSigner().getAddress();
 
     const gnosisModal = {
+      abortOperation: this.abortOperation,
       closeModal: this.closeModal,
       selectOption: this.selectOption,
       openModal: this.openModal,
@@ -432,6 +435,14 @@ export class GnosisDelegation implements SSXExtension {
     document
       .getElementById(`ssx-gnosis-modal--option-${option}`)
       .classList.add('selected');
+  };
+
+  /**
+   * Abort operation and close Modal.
+   */
+  abortOperation = (message: string): void => {
+    this._failure(new Error(message));
+    this.closeModal();
   };
 
   /**


### PR DESCRIPTION
# Description

This fixes the SSX instance freezing if multisig modal is closed during the sign-in process.

# Type

- [x] Bug fix (non-breaking change which fixes an issue)

# Diligence Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
