### PR TITLE
Fixes Resolve ENS on unsupported networks

### DIFF
--- a/.changeset/hungry-toys-kneel.md
+++ b/.changeset/hungry-toys-kneel.md
@@ -1,0 +1,7 @@
+---
+'@spruceid/ssx-core': patch
+---
+
+Ensures users on a different network with `resolveEns` set to true don't experience sign-in failures.
+
+

--- a/packages/ssx-core/package.json
+++ b/packages/ssx-core/package.json
@@ -62,12 +62,13 @@
   "devDependencies": {
     "@microsoft/api-documenter": "^7.19.4",
     "@microsoft/api-extractor": "^7.33.7",
+    "@types/node": "^18.14.6",
     "@typescript-eslint/eslint-plugin": "^5.23.0",
     "@typescript-eslint/parser": "^5.23.0",
     "eslint": "^8.15.0",
     "eslint-config-prettier": "^8.5.0",
-    "prettier": "^2.6.2",
-    "ethers": "^5.6.8"
+    "ethers": "^5.6.8",
+    "prettier": "^2.6.2"
   },
   "peerDependencies": {
     "ethers": "^5.6.8"

--- a/packages/ssx-core/src/utils/utils.ts
+++ b/packages/ssx-core/src/utils/utils.ts
@@ -101,23 +101,25 @@ export const ssxResolveEns = async (
     promises.push(provider.getAvatar(address));
   }
 
-  await Promise.all(promises).then(([domain, avatarUrl]) => {
-    if (!resolveEnsOpts.domain && resolveEnsOpts.avatar) {
-      [domain, avatarUrl] = [undefined, domain];
-    }
-    if (domain) {
-      ens['domain'] = domain;
-    }
-    if (avatarUrl) {
-      ens['avatarUrl'] = avatarUrl;
-    }
-  });
+  await Promise.all(promises)
+    .then(([domain, avatarUrl]) => {
+      if (!resolveEnsOpts.domain && resolveEnsOpts.avatar) {
+        [domain, avatarUrl] = [undefined, domain];
+      }
+      if (domain) {
+        ens['domain'] = domain;
+      }
+      if (avatarUrl) {
+        ens['avatarUrl'] = avatarUrl;
+      }
+    })
+    .catch(console.error);
 
   return ens;
 };
 
 const LENS_API_LINKS = {
-  'matic':'https://api.lens.dev',
+  'matic': 'https://api.lens.dev',
   'maticmum': 'https://api-mumbai.lens.dev'
 }
 
@@ -149,7 +151,7 @@ export const ssxResolveLens = async (
   const networkName = (await provider.getNetwork()).name;
   const apiURL: string | null = LENS_API_LINKS[networkName];
 
-  if(!apiURL) {
+  if (!apiURL) {
     return `Can't resolve Lens to ${address} on network '${networkName}'. Use 'matic' (Polygon) or 'maticmum' (Mumbai) instead.`;
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6517,6 +6517,11 @@
   resolved "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz#2c0fafd78705e7a18b7906b5201a522719dc5190"
   integrity sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==
 
+"@types/node@^18.14.6":
+  version "18.14.6"
+  resolved "https://registry.npmjs.org/@types/node/-/node-18.14.6.tgz#ae1973dd2b1eeb1825695bb11ebfb746d27e3e93"
+  integrity sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA==
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
   resolved "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"


### PR DESCRIPTION
# Description

This ensures users on a different network with `resolveEns` set to true don't experience login failures.

# Type

- [x] Bug fix (non-breaking change which fixes an issue)

# Diligence Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
