### PR TITLE
Fixes redirection to /protected route

### DIFF
--- a/examples/ssx-test-nextauth/pages/protected.tsx
+++ b/examples/ssx-test-nextauth/pages/protected.tsx
@@ -1,18 +1,20 @@
 import React from "react";
 import styles from '../styles/Protected.module.css'
-import { useSession } from 'next-auth/react';
-import { useRouter } from 'next/router';
+import { useSession, signOut as nextauthSignOut } from 'next-auth/react';
 import { useSSX } from "@spruceid/ssx-react";
 
 
 export default function Protected() {
-    const router = useRouter();
     const { data: session, status } = useSession();
     const { ssx, ssxLoaded } = useSSX();
 
     const signOut = async () => {
-        await ssx?.signOut();
-        router.push('/')
+        try {
+            await ssx?.signOut();
+        } catch(e) {
+            console.error(e);
+        }
+        nextauthSignOut({ callbackUrl: '/' });
     }
     
 


### PR DESCRIPTION
# Description

This fixes the `ssx-test-nextauth` example allowing the user to go back to the protected route.

# Type

- [x] Example update

# Diligence Checklist

- [x] This change requires a documentation update
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
