### PR TITLE
update peer generation call to match kepler update

### DIFF
--- a/packages/ssx-core/package.json
+++ b/packages/ssx-core/package.json
@@ -54,7 +54,7 @@
     "url": "git+https://github.com/spruceid/ssx.git"
   },
   "dependencies": {
-    "@spruceid/ssx-sdk-wasm": "0.2.0",
+    "@spruceid/ssx-sdk-wasm": "0.2.1",
     "axios": "^0.27.2",
     "ethers": "^5.7.2",
     "events": "^3.3.0",

--- a/packages/ssx-sdk/package.json
+++ b/packages/ssx-sdk/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@metamask/detect-provider": "^1.2.0",
     "@spruceid/ssx-core": "1.2.0",
-    "@spruceid/ssx-sdk-wasm": "0.2.0",
+    "@spruceid/ssx-sdk-wasm": "0.2.1",
     "assert": "^2.0.0",
     "axios": "^0.27.2",
     "browser": "^0.2.6",

--- a/packages/ssx-sdk/src/modules/Storage/kepler/orbit.ts
+++ b/packages/ssx-sdk/src/modules/Storage/kepler/orbit.ts
@@ -280,7 +280,7 @@ export const hostOrbit = async (
   const address = await wallet.getAddress();
   const chainId = await wallet.getChainId();
   const issuedAt = new Date(Date.now()).toISOString();
-  const peerId = await fetch(keplerUrl + '/peer/generate/${encodeURIComponent(orbitId)}').then(
+  const peerId = await fetch(keplerUrl + `/peer/generate/${encodeURIComponent(orbitId)}`).then(
     (res: FetchResponse) => res.text()
   );
   const config: HostConfig = {

--- a/packages/ssx-sdk/src/modules/Storage/kepler/orbit.ts
+++ b/packages/ssx-sdk/src/modules/Storage/kepler/orbit.ts
@@ -280,7 +280,7 @@ export const hostOrbit = async (
   const address = await wallet.getAddress();
   const chainId = await wallet.getChainId();
   const issuedAt = new Date(Date.now()).toISOString();
-  const peerId = await fetch(keplerUrl + '/peer/generate').then(
+  const peerId = await fetch(keplerUrl + '/peer/generate/${encodeURIComponent(orbitId)}').then(
     (res: FetchResponse) => res.text()
   );
   const config: HostConfig = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3880,10 +3880,10 @@
     uri-js "^4.4.1"
     valid-url "^1.0.9"
 
-"@spruceid/ssx-sdk-wasm@0.2.0":
-  version "0.2.0"
-  resolved "https://registry.npmjs.org/@spruceid/ssx-sdk-wasm/-/ssx-sdk-wasm-0.2.0.tgz#e7d45f32bdc3f365afc7f6e9738d964474098496"
-  integrity sha512-9qLxeiltCHpZ5EFAQ3qkrbzZHRZBCuvyAVR8IlG3NNXnmiG05InVHhqazR3TPDS48Kxsi12+mx1f6MvV6O4eCw==
+"@spruceid/ssx-sdk-wasm@0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@spruceid/ssx-sdk-wasm/-/ssx-sdk-wasm-0.2.1.tgz#2357b41753c99a3e6414538a812cfb28a6a57756"
+  integrity sha512-KAuUtXKGVHHqZ2eA0hmyI9mZkiQ0j+/92M/8QytB9kY8kb1se3UShZhqg/oslBUcK140ZFYNkgWmYaXeuGKS4Q==
 
 "@stablelib/aead@^1.0.1":
   version "1.0.1"


### PR DESCRIPTION
# Description

A [recent kepler update](https://github.com/spruceid/kepler/pull/146) adds a requirement that calls to `/peer/generate` must include a URI encoded orbit ID in the path (`/peer/generate/<orbit-id>`). This PR adds that. There is a corresponding PR in ssx-rs which fixes an issue with expiry times in invocations in kepler-sdk by bumping the dependency version, which should also be merged/released and included here as a version increment. Once these are done, ssx should be fully compatible with the latest version of Kepler, without any external API change (can probably be released as a patch version).

TODO:
- [x] bump the `@spruceid/ssx-wasm-sdk` version once it's released

# Type

- [ ] Release (a release should be published after this PR is merged)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Diligence Checklist

(Please delete options that are not relevant)

- [ ] I added a changelog with all changes I made in this PR
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have updated and/or included unit tests
- [ ] I have updated and/or included new end-to-end tests
