### PR TITLE
set prefix correctly in kepler deleteAll

### DIFF
--- a/packages/ssx-sdk/src/modules/Storage/KeplerStorage.ts
+++ b/packages/ssx-sdk/src/modules/Storage/KeplerStorage.ts
@@ -177,7 +177,7 @@ export class KeplerStorage implements IStorage, IKepler {
 
   public async deleteAll(prefix?: string): Promise<Response[]> {
     if (!!prefix) {
-      return this.orbit.deleteAll(`${this.prefix}${prefix}`);
+      return this.orbit.deleteAll(`${this.prefix}/${prefix}`);
     } else {
       return this.orbit.deleteAll(this.prefix);
     }

--- a/packages/ssx-sdk/src/modules/Storage/KeplerStorage.ts
+++ b/packages/ssx-sdk/src/modules/Storage/KeplerStorage.ts
@@ -175,8 +175,12 @@ export class KeplerStorage implements IStorage, IKepler {
     return this.orbit.delete(`${prefix}/${key}`, request);
   }
 
-  public async deleteAll(prefix: string = this.prefix): Promise<Response[]> {
-    return this.orbit.deleteAll(prefix);
+  public async deleteAll(prefix?: string): Promise<Response[]> {
+    if (!!prefix) {
+      return this.orbit.deleteAll(`${this.prefix}${prefix}`);
+    } else {
+      return this.orbit.deleteAll(this.prefix);
+    }
   }
 
   public async activateSession(


### PR DESCRIPTION
# Description

Currently `deleteAll` will overwrite the existing session prefix with the provided argument. This can easily lead to unintentional deletion of large amounts of stored content. This PR ensures the provided argument is appended to the session prefix. In future, we should consider similar behaviour in other storage methods, however it's not as much of a problem as those calls will fail if a non-delegated location is provided.

# Type

- [ ] Release (a release should be published after this PR is merged)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Diligence Checklist

(Please delete options that are not relevant)

- [ ] I added a changelog with all changes I made in this PR
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have updated and/or included unit tests
- [ ] I have updated and/or included new end-to-end tests
- [ ] I have made corresponding changes to the documentation (if required)
- [ ] Any dependent changes have been merged and published in downstream modules
