### PR TITLE
Adds Credentials Module

### DIFF
--- a/.changeset/chatty-doors-tap.md
+++ b/.changeset/chatty-doors-tap.md
@@ -6,7 +6,6 @@ This adds the Credentials Modules, which allows developers to fetch credentials 
 This module requires Storage Module, so you must enable both to make it work.
 
 ```ts
-
 const ssx = SSX({
   modules: {
     storage: true,

--- a/.changeset/chatty-doors-tap.md
+++ b/.changeset/chatty-doors-tap.md
@@ -1,0 +1,20 @@
+---
+'@spruceid/ssx': minor
+---
+
+This adds the Credentials Modules, which allows developers to fetch credentials issued on SpruceKit Credential Issuer. 
+This module requires Storage Module, so you must enable both to make it work.
+
+```ts
+
+const ssx = SSX({
+  modules: {
+    storage: true,
+    credentials: true
+  }
+})
+
+await ssx.signIn();
+
+const { data } = ssx.credentials.list();
+```

--- a/examples/ssx-test-app/src/pages/Home.tsx
+++ b/examples/ssx-test-app/src/pages/Home.tsx
@@ -50,6 +50,7 @@ function Home() {
   const [statement, setStatement] = useState<string>('');
   // ssx module config
   const [storageEnabled, setStorageEnabled] = useState<string>('Off');
+  const [credentialsEnabled, setCredentialsEnabled] = useState('Off');
 
   const getSSXConfig = (ssxConfig: Record<string, any> = {}) => {
     if (server === 'On') {
@@ -110,6 +111,10 @@ function Home() {
 
     if (storageEnabled === "On") {
       modules.storage = true;
+    }
+
+    if (credentialsEnabled === "On") {
+      modules.credentials = true;
     }
 
     if (modules) {
@@ -312,6 +317,19 @@ function Home() {
                   options={['On', 'Off']}
                   value={storageEnabled}
                   onChange={setStorageEnabled}
+                />
+              </div>
+            </div>
+            <div className='Dropdown-item'>
+              <span className='Dropdown-item-name'>
+                Credentials
+              </span>
+              <div className='Dropdown-item-options'>
+                <RadioGroup
+                  name='credentialsEnabled'
+                  options={['On', 'Off']}
+                  value={credentialsEnabled}
+                  onChange={setCredentialsEnabled}
                 />
               </div>
             </div>

--- a/examples/ssx-test-app/src/pages/StorageModule.tsx
+++ b/examples/ssx-test-app/src/pages/StorageModule.tsx
@@ -9,17 +9,24 @@ interface IStorageModule {
 
 function StorageModule({ ssx }: IStorageModule) {
   const [contentList, setContentList] = useState<Array<string>>([]);
+  const [credentialsList, setCredentialsList] = useState<Array<string>>([]);
   const [selectedContent, setSelectedContent] = useState<string | null>(null);
   const [name, setName] = useState<string>('');
   const [text, setText] = useState<string>('');
   const [viewingList, setViewingList] = useState<boolean>(true);
+  const [allowPost, setAllowPost] = useState<boolean>(false);
 
   useEffect(() => {
     const getContentList = async () => {
       const { data } = await ssx.storage.list({ removePrefix: true });
       setContentList(data);
     };
+    const getCredentialList = async () => {
+      const { data } = await ssx.credentials?.list?.({ removePrefix: true });
+      setCredentialsList(data);
+    };
     getContentList();
+    getCredentialList();
   }, [ssx]);
 
   const handleShareContent = async (content: string) => {
@@ -33,6 +40,7 @@ function StorageModule({ ssx }: IStorageModule) {
 
   const handleGetContent = async (content: string) => {
     const { data } = await ssx.storage.get(content);
+    setAllowPost(true);
     setSelectedContent(content);
     setName(content);
     setText(data);
@@ -75,6 +83,15 @@ function StorageModule({ ssx }: IStorageModule) {
     setViewingList(false);
   };
 
+  const handleGetCredential = async (content: string) => {
+    const { data } = await ssx.credentials.get(content);
+    setAllowPost(false);
+    setSelectedContent(content);
+    setName(content);
+    setText(data);
+    setViewingList(false);
+  };
+
   return (
     <div className="Content" style={{ marginTop: '30px' }}>
       <div className="storage-container Content-container">
@@ -102,13 +119,28 @@ function StorageModule({ ssx }: IStorageModule) {
               </div>
             ))}
             <Button onClick={handlePostNewContent}>Post new content</Button>
+            <h3>Credentials List</h3>
+            {credentialsList.map(content => (
+              <div className="item-container" key={content}>
+                <span>{content}</span>
+                <Button
+                  className="smallButton"
+                  onClick={() => handleGetCredential(content)}>
+                  Get
+                </Button>
+              </div>
+            ))}
           </div>
         ) : (
           <div className="View-pane">
             <h3>View/Edit/Post Pane</h3>
             <Input label="Key" value={name} onChange={setName} />
             <Input label="Text" value={text} onChange={setText} />
-            <Button onClick={handlePostContent}>Post</Button>
+            {
+              allowPost ?
+                <Button onClick={handlePostContent}>Post</Button> :
+                null
+            }
             <Button onClick={() => setViewingList(true)}>Back</Button>
           </div>
         )}

--- a/packages/ssx-sdk/src/modules/Credentials.ts
+++ b/packages/ssx-sdk/src/modules/Credentials.ts
@@ -28,7 +28,7 @@ export interface ICredentials extends SSXExtension {
 export class Credentials implements ICredentials {
   public namespace = 'credentials';
   private prefix: string = 'shared/credentials';
-  private storage?: IStorage;
+  private storage: IStorage;
 
   constructor(storage: IStorage) {
     this.storage = storage;

--- a/packages/ssx-sdk/src/modules/Credentials.ts
+++ b/packages/ssx-sdk/src/modules/Credentials.ts
@@ -1,0 +1,49 @@
+import { SSXExtension } from "@spruceid/ssx-core/client";
+import { IStorage } from "./Storage";
+import { Response, Request } from './Storage/kepler';
+
+
+export interface ICredentialsList {
+  credentialType?: string,
+  request?: Request,
+  removePrefix?: boolean
+}
+
+export interface ICredentials extends SSXExtension {
+  /**
+   * Retrieves the stored value associated with the specified credential key.
+   * @param credential - The unique identifier for the stored value.
+   * @returns A Promise that resolves to the value associated with the given credential key or undefined if the credential key does not exist.
+   */
+  get(credential: string): Promise<Response>;
+
+  /**
+   * Lists all credential keys available.
+   * @param credentialType - The credential identifier for the stored value.
+   * @returns A Promise that resolves to an array of strings representing the stored credentials keys.
+   */
+  list(options: ICredentialsList): Promise<Response>;
+
+}
+export class Credentials implements ICredentials {
+  public namespace = 'credentials';
+  private prefix: string = 'shared/credentials';
+  private storage?: IStorage;
+
+  constructor(storage: IStorage) {
+    this.storage = storage;
+  }
+
+  public async get(credential: string): Promise<Response> {
+    return this.storage.get(credential, { prefix: this.prefix });
+  }
+
+  public async list(options: ICredentialsList): Promise<Response> {
+    const defaultOptions = {
+      prefix: this.prefix,
+    };
+    const { prefix, credentialType, request, removePrefix } = { ...defaultOptions, ...options };
+    return this.storage.list({ prefix, path: credentialType, removePrefix, request });
+  }
+
+}

--- a/packages/ssx-sdk/src/modules/Storage/KeplerStorage.ts
+++ b/packages/ssx-sdk/src/modules/Storage/KeplerStorage.ts
@@ -49,6 +49,7 @@ export class KeplerStorage implements IStorage, IKepler {
   private autoCreateNewOrbit: boolean;
   private userAuth: IUserAuthorization;
   private keplerModule?: any;
+  private credentialsModule?: boolean;
   /** The users orbitId. */
   public orbitId?: string;
 
@@ -65,6 +66,7 @@ export class KeplerStorage implements IStorage, IKepler {
     this.userAuth = userAuth;
     this.hosts = [...(config?.hosts || []), 'https://kepler.spruceid.xyz'];
     this.prefix = config?.prefix || '';
+    this.credentialsModule = config?.credentialsModule;
     this.autoCreateNewOrbit =
       config?.autoCreateNewOrbit === undefined
         ? true
@@ -98,6 +100,13 @@ export class KeplerStorage implements IStorage, IKepler {
       'del',
       'metadata',
     ];
+    if (this.credentialsModule) {
+      actions[`${this.orbitId}/kv/shared/credentials`] = [
+        'get',
+        'list',
+        'metadata',
+      ];
+    }
     return actions;
   }
 

--- a/packages/ssx-sdk/src/modules/index.ts
+++ b/packages/ssx-sdk/src/modules/index.ts
@@ -1,2 +1,3 @@
 export * from './UserAuthorization';
 export * from './Storage';
+export * from './Credentials';


### PR DESCRIPTION
# Description

This adds the Credentials Modules, which allows developers to fetch credentials issued on SpruceKit Credential Issuer. 
This module requires Storage Module, so you must enable both to make it work. 

```ts
const ssx = SSX({
  modules: {
    storage: true,
    credentials: true
  }
})

await ssx.signIn();

const { data } = ssx.credentials.list();
```

# Type

- [x] New feature (non-breaking change which adds functionality)

# Diligence Checklist

- [x] I added a changelog with all changes I made in this PR
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation (if required)
- [x] Any dependent changes have been merged and published in downstream modules
